### PR TITLE
EMB-1273 Clear LCD memory in initialization

### DIFF
--- a/components/lvgl_esp32_drivers/lvgl_tft/disp_spi.h
+++ b/components/lvgl_esp32_drivers/lvgl_tft/disp_spi.h
@@ -74,6 +74,10 @@ static inline void disp_spi_send_colors(uint8_t *data, size_t length) {
         NULL, 0, 0);
 }
 
+static inline void disp_spi_send_colors_polling(uint8_t *data, size_t length) {
+    disp_spi_transaction(data, length, DISP_SPI_SEND_POLLING, NULL, 0, 0);
+}
+
 #ifdef __cplusplus
 } /* extern "C" */
 #endif

--- a/components/lvgl_esp32_drivers/lvgl_tft/st7789.h
+++ b/components/lvgl_esp32_drivers/lvgl_tft/st7789.h
@@ -108,6 +108,7 @@ extern "C"
 void st7789_init(void);
 void st7789_flush(lv_disp_drv_t *drv, const lv_area_t *area, lv_color_t *color_map);
 void st7789_enable_backlight(bool backlight);
+void st7789_disp_on(void);
 
 #ifdef __cplusplus
 } /* extern "C" */


### PR DESCRIPTION
1. Removed DISPON command from initialize commands list
2. Added screen clearing after initialize commands list
3. Added DISPON command after screen clearing